### PR TITLE
fix: replace missing image url with placeholder image

### DIFF
--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image,
+        image: this.props.image || '/placeholder.png',
         tagList: this.props.tagList,
       };
 

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image || '/placeholder.png',
+        image: this.props.image || "/placeholder.png",
         tagList: this.props.tagList,
       };
 

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image || "/placeholder.png",
+        image: this.props.image,
         tagList: this.props.tagList,
       };
 

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -38,6 +38,10 @@ class Item extends React.Component {
       return null;
     }
 
+    if (!this.props.item.image) {
+      this.props.item.image = "/placeholder.png";
+    }
+
     const markup = {
       __html: marked(this.props.item.description, { sanitize: true }),
     };

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,6 +20,10 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
+  if (!item.image) {
+    item.image = "/placeholder.png";
+  }
+
   const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {


### PR DESCRIPTION
Submit placeholder image if no image url is given in the item editor form. 

Fixes #3 
<img width="692" alt="Screen Shot 2022-07-17 at 12 13 06 AM" src="https://user-images.githubusercontent.com/11450156/179385046-09f90ee5-8f3f-4594-a42d-18a717a24255.png">

