### PR TITLE
fix: add placeholder for missing images in api requests

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -1,18 +1,23 @@
-var router = require("express").Router();
-var mongoose = require("mongoose");
-var Item = mongoose.model("Item");
-var Comment = mongoose.model("Comment");
-var User = mongoose.model("User");
-var auth = require("../auth");
-const { sendEvent } = require("../../lib/event");
+var router = require('express').Router();
+var mongoose = require('mongoose');
+var Item = mongoose.model('Item');
+var Comment = mongoose.model('Comment');
+var User = mongoose.model('User');
+var auth = require('../auth');
+const { sendEvent } = require('../../lib/event');
 
 // Preload item objects on routes with ':item'
-router.param("item", function(req, res, next, slug) {
+router.param('item', function (req, res, next, slug) {
   Item.findOne({ slug: slug })
-    .populate("seller")
-    .then(function(item) {
+    .populate('seller')
+    .then(function (item) {
       if (!item) {
         return res.sendStatus(404);
+      }
+
+      // Add placeholder image if item image is missing
+      if (!item.image) {
+        item.image = '/placeholder.png';
       }
 
       req.item = item;
@@ -22,9 +27,9 @@ router.param("item", function(req, res, next, slug) {
     .catch(next);
 });
 
-router.param("comment", function(req, res, next, id) {
+router.param('comment', function (req, res, next, id) {
   Comment.findById(id)
-    .then(function(comment) {
+    .then(function (comment) {
       if (!comment) {
         return res.sendStatus(404);
       }
@@ -36,28 +41,30 @@ router.param("comment", function(req, res, next, id) {
     .catch(next);
 });
 
-router.get("/", auth.optional, function(req, res, next) {
+router.get('/', auth.optional, function (req, res, next) {
   var query = {};
   var limit = 100;
   var offset = 0;
 
-  if (typeof req.query.limit !== "undefined") {
+  if (typeof req.query.limit !== 'undefined') {
     limit = req.query.limit;
   }
 
-  if (typeof req.query.offset !== "undefined") {
+  if (typeof req.query.offset !== 'undefined') {
     offset = req.query.offset;
   }
 
-  if (typeof req.query.tag !== "undefined") {
+  if (typeof req.query.tag !== 'undefined') {
     query.tagList = { $in: [req.query.tag] };
   }
 
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
-    req.query.favorited ? User.findOne({ username: req.query.favorited }) : null
+    req.query.favorited
+      ? User.findOne({ username: req.query.favorited })
+      : null,
   ])
-    .then(function(results) {
+    .then(function (results) {
       var seller = results[0];
       var favoriter = results[1];
 
@@ -75,41 +82,47 @@ router.get("/", auth.optional, function(req, res, next) {
         Item.find(query)
           .limit(Number(limit))
           .skip(Number(offset))
-          .sort({ createdAt: "desc" })
+          .sort({ createdAt: 'desc' })
           .exec(),
         Item.count(query).exec(),
-        req.payload ? User.findById(req.payload.id) : null
-      ]).then(async function(results) {
+        req.payload ? User.findById(req.payload.id) : null,
+      ]).then(async function (results) {
         var items = results[0];
         var itemsCount = results[1];
         var user = results[2];
         return res.json({
           items: await Promise.all(
-            items.map(async function(item) {
+            items.map(async function (item) {
               item.seller = await User.findById(item.seller);
+
+              // Add placeholder image if item image is missing
+              if (!item.image) {
+                item.image = '/placeholder.png';
+              }
+
               return item.toJSONFor(user);
             })
           ),
-          itemsCount: itemsCount
+          itemsCount: itemsCount,
         });
       });
     })
     .catch(next);
 });
 
-router.get("/feed", auth.required, function(req, res, next) {
+router.get('/feed', auth.required, function (req, res, next) {
   var limit = 20;
   var offset = 0;
 
-  if (typeof req.query.limit !== "undefined") {
+  if (typeof req.query.limit !== 'undefined') {
     limit = req.query.limit;
   }
 
-  if (typeof req.query.offset !== "undefined") {
+  if (typeof req.query.offset !== 'undefined') {
     offset = req.query.offset;
   }
 
-  User.findById(req.payload.id).then(function(user) {
+  User.findById(req.payload.id).then(function (user) {
     if (!user) {
       return res.sendStatus(401);
     }
@@ -118,28 +131,28 @@ router.get("/feed", auth.required, function(req, res, next) {
       Item.find({ seller: { $in: user.following } })
         .limit(Number(limit))
         .skip(Number(offset))
-        .populate("seller")
+        .populate('seller')
         .exec(),
-      Item.count({ seller: { $in: user.following } })
+      Item.count({ seller: { $in: user.following } }),
     ])
-      .then(function(results) {
+      .then(function (results) {
         var items = results[0];
         var itemsCount = results[1];
 
         return res.json({
-          items: items.map(function(item) {
+          items: items.map(function (item) {
             return item.toJSONFor(user);
           }),
-          itemsCount: itemsCount
+          itemsCount: itemsCount,
         });
       })
       .catch(next);
   });
 });
 
-router.post("/", auth.required, function(req, res, next) {
+router.post('/', auth.required, function (req, res, next) {
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
@@ -148,8 +161,8 @@ router.post("/", auth.required, function(req, res, next) {
 
       item.seller = user;
 
-      return item.save().then(function() {
-        sendEvent('item_created', { item: req.body.item })
+      return item.save().then(function () {
+        sendEvent('item_created', { item: req.body.item });
         return res.json({ item: item.toJSONFor(user) });
       });
     })
@@ -157,12 +170,12 @@ router.post("/", auth.required, function(req, res, next) {
 });
 
 // return a item
-router.get("/:item", auth.optional, function(req, res, next) {
+router.get('/:item', auth.optional, function (req, res, next) {
   Promise.all([
     req.payload ? User.findById(req.payload.id) : null,
-    req.item.populate("seller").execPopulate()
+    req.item.populate('seller').execPopulate(),
   ])
-    .then(function(results) {
+    .then(function (results) {
       var user = results[0];
 
       return res.json({ item: req.item.toJSONFor(user) });
@@ -171,28 +184,28 @@ router.get("/:item", auth.optional, function(req, res, next) {
 });
 
 // update item
-router.put("/:item", auth.required, function(req, res, next) {
-  User.findById(req.payload.id).then(function(user) {
+router.put('/:item', auth.required, function (req, res, next) {
+  User.findById(req.payload.id).then(function (user) {
     if (req.item.seller._id.toString() === req.payload.id.toString()) {
-      if (typeof req.body.item.title !== "undefined") {
+      if (typeof req.body.item.title !== 'undefined') {
         req.item.title = req.body.item.title;
       }
 
-      if (typeof req.body.item.description !== "undefined") {
+      if (typeof req.body.item.description !== 'undefined') {
         req.item.description = req.body.item.description;
       }
 
-      if (typeof req.body.item.image !== "undefined") {
+      if (typeof req.body.item.image !== 'undefined') {
         req.item.image = req.body.item.image;
       }
 
-      if (typeof req.body.item.tagList !== "undefined") {
+      if (typeof req.body.item.tagList !== 'undefined') {
         req.item.tagList = req.body.item.tagList;
       }
 
       req.item
         .save()
-        .then(function(item) {
+        .then(function (item) {
           return res.json({ item: item.toJSONFor(user) });
         })
         .catch(next);
@@ -203,15 +216,15 @@ router.put("/:item", auth.required, function(req, res, next) {
 });
 
 // delete item
-router.delete("/:item", auth.required, function(req, res, next) {
+router.delete('/:item', auth.required, function (req, res, next) {
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
 
       if (req.item.seller._id.toString() === req.payload.id.toString()) {
-        return req.item.remove().then(function() {
+        return req.item.remove().then(function () {
           return res.sendStatus(204);
         });
       } else {
@@ -222,17 +235,17 @@ router.delete("/:item", auth.required, function(req, res, next) {
 });
 
 // Favorite an item
-router.post("/:item/favorite", auth.required, function(req, res, next) {
+router.post('/:item/favorite', auth.required, function (req, res, next) {
   var itemId = req.item._id;
 
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
 
-      return user.favorite(itemId).then(function() {
-        return req.item.updateFavoriteCount().then(function(item) {
+      return user.favorite(itemId).then(function () {
+        return req.item.updateFavoriteCount().then(function (item) {
           return res.json({ item: item.toJSONFor(user) });
         });
       });
@@ -241,17 +254,17 @@ router.post("/:item/favorite", auth.required, function(req, res, next) {
 });
 
 // Unfavorite an item
-router.delete("/:item/favorite", auth.required, function(req, res, next) {
+router.delete('/:item/favorite', auth.required, function (req, res, next) {
   var itemId = req.item._id;
 
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
 
-      return user.unfavorite(itemId).then(function() {
-        return req.item.updateFavoriteCount().then(function(item) {
+      return user.unfavorite(itemId).then(function () {
+        return req.item.updateFavoriteCount().then(function (item) {
           return res.json({ item: item.toJSONFor(user) });
         });
       });
@@ -260,27 +273,27 @@ router.delete("/:item/favorite", auth.required, function(req, res, next) {
 });
 
 // return an item's comments
-router.get("/:item/comments", auth.optional, function(req, res, next) {
+router.get('/:item/comments', auth.optional, function (req, res, next) {
   Promise.resolve(req.payload ? User.findById(req.payload.id) : null)
-    .then(function(user) {
+    .then(function (user) {
       return req.item
         .populate({
-          path: "comments",
+          path: 'comments',
           populate: {
-            path: "seller"
+            path: 'seller',
           },
           options: {
             sort: {
-              createdAt: "desc"
-            }
-          }
+              createdAt: 'desc',
+            },
+          },
         })
         .execPopulate()
-        .then(function(item) {
+        .then(function (item) {
           return res.json({
-            comments: req.item.comments.map(function(comment) {
+            comments: req.item.comments.map(function (comment) {
               return comment.toJSONFor(user);
-            })
+            }),
           });
         });
     })
@@ -288,9 +301,9 @@ router.get("/:item/comments", auth.optional, function(req, res, next) {
 });
 
 // create a new comment
-router.post("/:item/comments", auth.required, function(req, res, next) {
+router.post('/:item/comments', auth.required, function (req, res, next) {
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
@@ -299,10 +312,10 @@ router.post("/:item/comments", auth.required, function(req, res, next) {
       comment.item = req.item;
       comment.seller = user;
 
-      return comment.save().then(function() {
+      return comment.save().then(function () {
         req.item.comments = req.item.comments.concat([comment]);
 
-        return req.item.save().then(function(item) {
+        return req.item.save().then(function (item) {
           res.json({ comment: comment.toJSONFor(user) });
         });
       });
@@ -310,26 +323,22 @@ router.post("/:item/comments", auth.required, function(req, res, next) {
     .catch(next);
 });
 
-router.delete("/:item/comments/:comment", auth.required, function(
-  req,
-  res,
-  next
-) {
-  if (req.comment.seller.toString() === req.payload.id.toString()) {
-    req.item.comments.remove(req.comment._id);
-    req.item
-      .save()
-      .then(
-        Comment.find({ _id: req.comment._id })
-          .remove()
-          .exec()
-      )
-      .then(function() {
-        res.sendStatus(204);
-      });
-  } else {
-    res.sendStatus(403);
+router.delete(
+  '/:item/comments/:comment',
+  auth.required,
+  function (req, res, next) {
+    if (req.comment.seller.toString() === req.payload.id.toString()) {
+      req.item.comments.remove(req.comment._id);
+      req.item
+        .save()
+        .then(Comment.find({ _id: req.comment._id }).remove().exec())
+        .then(function () {
+          res.sendStatus(204);
+        });
+    } else {
+      res.sendStatus(403);
+    }
   }
-});
+);
 
 module.exports = router;


### PR DESCRIPTION
When there are no images stored for items in the database, API requests for those items return an empty string for the image property. This adds the placeholder image if item images are missing.
Fixes #3 
