### PR TITLE
fix: Remove min-width property from profile page .user-info div

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -1,4 +1,4 @@
-@import url('http://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700,800');
+@import url("http://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700,800");
 
 // Override default variables before the import
 $primary: #2b1456;
@@ -12,18 +12,18 @@ $light: #af93f2;
 
 $input-border-color: #d0d0d0;
 
-$font-family-base: 'Poppins', sans-serif !important;
+$font-family-base: "Poppins", sans-serif !important;
 
 $theme-colors: (
-  'light-gray': #f2f2f2,
+  "light-gray": #f2f2f2,
 );
 
 // Import Bootstrap and its default variables
-@import '~bootstrap/scss/bootstrap.scss';
-@import '~bootstrap-icons/font/bootstrap-icons.css';
+@import "~bootstrap/scss/bootstrap.scss";
+@import "~bootstrap-icons/font/bootstrap-icons.css";
 
 body {
-  background-image: url('./imgs/background.png');
+  background-image: url("./imgs/background.png");
   background-position: top;
   background-repeat: no-repeat;
 }

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700,800");
+@import url('http://fonts.googleapis.com/css?family=Poppins:300,400,500,600,700,800');
 
 // Override default variables before the import
 $primary: #2b1456;
@@ -12,18 +12,18 @@ $light: #af93f2;
 
 $input-border-color: #d0d0d0;
 
-$font-family-base: "Poppins", sans-serif !important;
+$font-family-base: 'Poppins', sans-serif !important;
 
 $theme-colors: (
-  "light-gray": #f2f2f2,
+  'light-gray': #f2f2f2,
 );
 
 // Import Bootstrap and its default variables
-@import "~bootstrap/scss/bootstrap.scss";
-@import "~bootstrap-icons/font/bootstrap-icons.css";
+@import '~bootstrap/scss/bootstrap.scss';
+@import '~bootstrap-icons/font/bootstrap-icons.css';
 
 body {
-  background-image: url("./imgs/background.png");
+  background-image: url('./imgs/background.png');
   background-position: top;
   background-repeat: no-repeat;
 }
@@ -54,8 +54,4 @@ body {
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-}
-
-.user-info {
-  min-width: 800px;
 }


### PR DESCRIPTION
Removed `min-width: 800px` property from `div.user-info` which was causing the Profile page follow button (and other content within that div) to be pushed off-screen on mobile devices. This was likely the cause for the drop in user follow success from mobile users.
