### PR TITLE
fix: correct mongoose query for /api/tags route

### DIFF
--- a/backend/routes/api/tags.js
+++ b/backend/routes/api/tags.js
@@ -1,12 +1,15 @@
-var router = require('express').Router();
-var mongoose = require('mongoose');
-var Item = mongoose.model('Item');
+var router = require("express").Router();
+var mongoose = require("mongoose");
+var Item = mongoose.model("Item");
 
 // return a list of tags
-router.get('/', function(req, res, next) {
-  Item.find().distincts('tagList').then(function(tags){
-    return res.json({tags: tags});
-  }).catch(next);
+router.get("/", function (req, res, next) {
+  Item.find()
+    .distinct("tagList")
+    .then(function (tags) {
+      return res.json({ tags: tags });
+    })
+    .catch(next);
 });
 
 module.exports = router;


### PR DESCRIPTION
# Description

Corrected the mongoose query for /api/tags route. There is no `Item.find().distincts()` function. It should be `Item.find().distinct()`.  
